### PR TITLE
Adiciona rotas de follow/unfollow de usuários no back

### DIFF
--- a/game-slot/backend/controllers/user.js
+++ b/game-slot/backend/controllers/user.js
@@ -20,4 +20,102 @@ module.exports = {
 
     return res.status(200).json({ user })
   },
+  follow: async function (req, res) {
+    const { id: userToFollowId } = req.params
+    const { userId: followerId } = req.body
+
+    if (!followerId) {
+      return res
+        .status(400)
+        .json({ error: 'you must provide userId in request body' })
+    }
+
+    if (followerId === userToFollowId) {
+      return res.status(400).json({
+        error: `user '${followerId}' can't follow itself`,
+      })
+    }
+
+    const userToFollow = await User.findById(userToFollowId)
+    const follower = await User.findById(followerId)
+
+    if (!userToFollow) {
+      return res
+        .status(404)
+        .json({ error: `user '${userToFollowId}' not found` })
+    }
+
+    if (!follower) {
+      return res.status(404).json({ error: `user '${followerId}' not found` })
+    }
+
+    if (
+      userToFollow.followers.includes(followerId) ||
+      follower.followings.includes(userToFollowId)
+    ) {
+      return res.status(404).json({
+        error: `user '${follower.email}' already follows user '${userToFollow.email}'`,
+      })
+    }
+
+    await userToFollow.updateOne({
+      $push: { followers: followerId },
+    })
+    await follower.updateOne({
+      $push: { followings: userToFollowId },
+    })
+
+    return res.status(200).json({
+      message: `user '${userToFollow.email}' has been followed by '${follower.email}'`,
+    })
+  },
+  unfollow: async function (req, res) {
+    const { id: userToUnfollowId } = req.params
+    const { userId: unfollowerId } = req.body
+
+    if (!unfollowerId) {
+      return res
+        .status(400)
+        .json({ error: 'you must provide userId in request body' })
+    }
+
+    if (unfollowerId === userToUnfollowId) {
+      return res.status(400).json({
+        error: `user '${unfollowerId}' can't unfollow itself`,
+      })
+    }
+
+    const userToUnfollow = await User.findById(userToUnfollowId)
+    const unfollower = await User.findById(unfollowerId)
+
+    if (!userToUnfollow) {
+      return res
+        .status(404)
+        .json({ error: `user '${userToUnfollowId}' not found` })
+    }
+
+    if (!unfollower) {
+      return res.status(404).json({ error: `user '${unfollowerId}' not found` })
+    }
+
+    if (
+      !userToUnfollow.followers.includes(unfollowerId) &&
+      !unfollower.followings.includes(userToUnfollowId)
+    ) {
+      return res.status(404).json({
+        error: `user '${unfollower.email}' isn't following user '${userToUnfollow.email}'`,
+      })
+    }
+
+    await userToUnfollow.updateOne({
+      $pull: { followers: unfollowerId },
+    })
+    await unfollower.updateOne({
+      $pull: { followings: userToUnfollowId },
+    })
+
+    return res.status(200).json({
+      message: `user '${userToUnfollow.email}' has been unfollowed by '${unfollower.email}'`,
+    })
+  },
 }

--- a/game-slot/backend/models/User.js
+++ b/game-slot/backend/models/User.js
@@ -8,6 +8,15 @@ const UserSchema = new Schema({
   email: {
     type: String,
     required: true,
+    unique: true,
+  },
+  followers: {
+    type: Array,
+    default: [],
+  },
+  followings: {
+    type: Array,
+    default: [],
   },
 })
 

--- a/game-slot/backend/routes/user.js
+++ b/game-slot/backend/routes/user.js
@@ -1,8 +1,10 @@
 const { Router } = require('express')
-const { list, getById } = require('../controllers/user')
+const { list, getById, follow, unfollow } = require('../controllers/user')
 const router = Router()
 
 router.get('/', list)
 router.get('/:id', getById)
+router.post('/follow/:id', follow)
+router.post('/unfollow/:id', unfollow)
 
 module.exports = router


### PR DESCRIPTION
Closes #43 

Esta PR adiciona duas rotas ao controlador de usuários: `POST /users/follow/:id` e `POST /users/unfollow/:id`.

Nessas duas rotas, você deve passar um `id` como parâmetro de URL, que corresponde ao usuário que deve ser seguido (ou "deseguido"), e mandar no corpo da requisição o `userId` do seguidor (ou "deseguidor").


https://user-images.githubusercontent.com/19390820/131865985-d282cd5d-010b-4268-b8f6-a80c39504057.mp4

