### PR TITLE
Adiciona rota para obter média de avaliações de um jogo

### DIFF
--- a/game-slot/backend/controllers/list.js
+++ b/game-slot/backend/controllers/list.js
@@ -85,8 +85,8 @@ module.exports = {
   },
 
   removeGame: async function (req, res) {
-    const { id, userId } = req.params
-    const { gameId } = req.body
+    const { id } = req.params
+    const { gameId, userId } = req.body
 
     try {
       const list = await removeGameFromList({ userId, listId: id, gameId })

--- a/game-slot/backend/controllers/review.js
+++ b/game-slot/backend/controllers/review.js
@@ -149,4 +149,11 @@ module.exports = {
 
     return res.status(200).json(response)
   },
+  averageRating: async function (req, res) {
+    const { id } = req.params
+
+    if (!id) res.status(404).json({ error: 'id not provided' })
+    const avg = await reviewService.getAverageRating(id)
+    return res.status(200).json({ average: avg })
+  },
 }

--- a/game-slot/backend/routes/review.js
+++ b/game-slot/backend/routes/review.js
@@ -11,11 +11,13 @@ const {
   like,
   dislike,
   getTimeline,
+  averageRating,
 } = require('../controllers/review')
 const router = express.Router()
 
 router.get('/:id', get)
 router.get('/game/:id', getAll)
+router.get('/game/:id/rating', averageRating)
 router.get('/user/:userId', getByUser)
 router.get('/game/:gameId/user/:userId', getByUserAndGame)
 router.post('/', checkJwt, create)

--- a/game-slot/backend/services/review.service.js
+++ b/game-slot/backend/services/review.service.js
@@ -225,4 +225,38 @@ module.exports = {
       hasNextPage,
     }
   },
+  getAverageRating: async function (gameId) {
+    const values = await Promise.all([
+      Review.countDocuments({
+        note: 0,
+        gameId,
+      }),
+      Review.countDocuments({
+        note: 1,
+        gameId,
+      }),
+      Review.countDocuments({
+        note: 2,
+        gameId,
+      }),
+      Review.countDocuments({
+        note: 3,
+        gameId,
+      }),
+      Review.countDocuments({
+        note: 4,
+        gameId,
+      }),
+      Review.countDocuments({
+        note: 5,
+        gameId,
+      }),
+    ])
+
+    const [zero, one, two, three, four, five] = values
+    const total = zero + one + two + three + four + five
+
+    if (total === 0) return -1
+    return (one + two * 2 + three * 3 + four * 4 + five * 5) / total
+  },
 }


### PR DESCRIPTION
### Mudanças 🚀 
- Adiciona rota /review/game/:id/rating 
- [NEW] Corrige bug na rota de remover um jogo de uma lista

### Observações 🔍 
A rota em questão possui o seguinte retorno: `{ average : 5 }`, dado um jogo de média 5. Caso o jogo não possua nenhuma avaliação, a média retornada é -1, para não confundir com um jogo com avaliação 0.

Atualmente na API é possível avaliar e contar as reviews de nota 0, mas não é possível avaliar um jogo com 0 no frontend. No entanto, isso não é uma limitação da API. Logo, optei por -1 uma vez que é um valor atípico e pode ser tratado devidamente.

### Relacionado 🔗 
It closes #111 